### PR TITLE
spelling fixes in the POD

### DIFF
--- a/lib/Test/Timer.pm
+++ b/lib/Test/Timer.pm
@@ -518,7 +518,7 @@ so the current implementation is limited to seconds as the highest resolution.
 
 On occassion failing tests with CPAN-testers have been observed. This seem to be related to the test-suite
 being not taking into account that some smoke-testers do not prioritize resources for the test run and that
-addional processes/jobs are running. The test-suite have been adjusted to accomodate this but these issues
+additional processes/jobs are running. The test-suite have been adjusted to accommodate this but these issues
 might reoccur.
 
 =head1 TEST AND QUALITY


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test-Timer.
We thought you might be interested in it too.

    Description: spelling fixes in the POD
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2017-07-08
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libtest-timer-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
